### PR TITLE
increase nixpkgs-review timeout to 120 minutes, increase python max package rebuilds from 25 to 100

### DIFF
--- a/doc/nixpkgs-maintainer-faq.md
+++ b/doc/nixpkgs-maintainer-faq.md
@@ -36,7 +36,7 @@ Updates can be disabled by adding a comment to the package:
 
 We maintain a [Skiplist](https://github.com/ryantm/nixpkgs-update/blob/main/src/Skiplist.hs) of different things not to update. It is possible your package is triggering one of the skip criteria.
 
-Python updates are skipped if they cause more than 25 rebuilds.
+Python updates are skipped if they cause more than 100 rebuilds.
 
 ### Existing Open or Draft PR
 

--- a/src/NixpkgsReview.hs
+++ b/src/NixpkgsReview.hs
@@ -34,7 +34,7 @@ run ::
   Text ->
   Sem r Text
 run cache commit =
-  let timeout = "45m" :: Text
+  let timeout = "120m" :: Text
    in do
         -- TODO: probably just skip running nixpkgs-review if the directory
         -- already exists

--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -234,4 +234,4 @@ python numPackageRebuilds derivationContents =
     (not isPython || numPackageRebuilds <= maxPackageRebuild)
   where
     isPython = "buildPythonPackage" `T.isInfixOf` derivationContents
-    maxPackageRebuild = 25
+    maxPackageRebuild = 100


### PR DESCRIPTION
Recently we've been running `nixpkgs-update` on better hardware and have also increased the number of workers so I think it makes sense to increase this timeout.

Increasing the python rebuilds was discussed in https://github.com/ryantm/nixpkgs-update/pull/185.

~~I'll wait a week for comments before deploying this to build02.~~ https://github.com/nix-community/infra/pull/1169