### PR TITLE
docs: add contact page with github and matrix links

### DIFF
--- a/doc/contact.md
+++ b/doc/contact.md
@@ -1,0 +1,5 @@
+# Contact {#contact}
+
+Github: [https://github.com/ryantm/nixpkgs-update](https://github.com/ryantm/nixpkgs-update)
+
+Matrix: [https://matrix.to/#/#nixpkgs-update:nixos.org](https://matrix.to/#/#nixpkgs-update:nixos.org)

--- a/doc/nixpkgs-maintainer-faq.md
+++ b/doc/nixpkgs-maintainer-faq.md
@@ -12,7 +12,7 @@ Thanks for being a maintainer. Hopefully, @r-ryantm will be able to save you som
 
 ## Why is @r-ryantm not updating my package? {#no-update}
 
-There are lots of reasons a package might not be updated. You can usually figure out which one is the issue by looking at the [logs](https://r.ryantm.com/log/) or by asking @ryantm on Matrix or GitHub.
+There are lots of reasons a package might not be updated. You can usually figure out which one is the issue by looking at the [logs](https://r.ryantm.com/log/) or by asking the [maintainers](#contact).
 
 ### No new version information
 

--- a/doc/toc.md
+++ b/doc/toc.md
@@ -9,3 +9,4 @@
 * [Contributing](#contributing)
 * [Donate](#donate)
 * [Nixpkgs Maintainer FAQ](#nixpkgs-maintainer-faq)
+* [Contact](#contact)


### PR DESCRIPTION
Wasn't really sure where to add the matrix room in the docs, having a separate contact page seems to be the most visible?