### PR TITLE
skiplist: add package sets that cause duplicate PRs

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -90,7 +90,17 @@ attrPathList =
     eq "klee" "update repeatedly exceeded the 6h timeout",
     regex
       (string "python" *> few (psym isDigit) *> string "Packages.mmengine")
-      "takes way too long to build"
+      "takes way too long to build",
+    prefix
+      "linuxKernel"
+      "creates too many duplicate PRs",
+    prefix
+      "postgresql"
+      "creates too many duplicate PRs",
+    prefix
+      -- bump this when the default version is changed
+      "python312Packages"
+      "isn't the default python version"
   ]
 
 nameList :: Skiplist


### PR DESCRIPTION
Until we have a proper fix for duplicates this it will at least reduce the noise a bit.

@mweinelt Are you okay with only allowing updates for `python311Packages` for now?