### PR TITLE
README: fix link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![Build Status](https://github.com/ryantm/nixpkgs-update/workflows/CI/badge.svg)](https://github.com/ryantm/nixpkgs-update/actions)
 [![Patreon](https://img.shields.io/badge/patreon-donate-blue.svg)](https://www.patreon.com/nixpkgsupdate)
 
-Please read the [documentation](https://ryantm.github.io/nixpkgs-update/).
+Please read the [documentation](https://nix-community.github.io/nixpkgs-update/).


### PR DESCRIPTION
This seems to be the only link that is actually broken since the repo move, everything else seems to follow redirects, I'll handle those in another PR.