### PR TITLE
Revert "allow nixpkgs-review to build insecure packages"

### DIFF
--- a/src/NixpkgsReview.hs
+++ b/src/NixpkgsReview.hs
@@ -43,7 +43,7 @@ run cache commit =
             proc "rm" ["-rf", revDir cache commit]
         (exitCode, _nixpkgsReviewOutput) <-
           ourReadProcessInterleavedSem $
-            proc "timeout" [T.unpack timeout, (binPath <> "/nixpkgs-review"), "rev", T.unpack commit, "--no-shell", "--extra-nixpkgs-config", "{ allowInsecurePredicate = x: true; }"]
+            proc "timeout" [T.unpack timeout, (binPath <> "/nixpkgs-review"), "rev", T.unpack commit, "--no-shell"]
         case exitCode of
           ExitFailure 124 -> do
             output $ "[check][nixpkgs-review] took longer than " <> timeout <> " and timed out"


### PR DESCRIPTION
This reverts commit 6e45a0911d03b8bf68c226f1d726e5cdd3f606ad.

not needed now that openssl_1_1 is disallowed

https://github.com/nix-community/nixpkgs-update/pull/391