### PR TITLE
skiplist: default python is now 3.12

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -99,7 +99,7 @@ attrPathList =
       "creates too many duplicate PRs",
     prefix
       -- bump this when the default version is changed
-      "python312Packages"
+      "python311Packages"
       "isn't the default python version"
   ]
 


### PR DESCRIPTION
Python 3.12 is now the default version on master.