### PR TITLE
skiplist: add vmagent package

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -88,6 +88,7 @@ attrPathList =
     eq "flint" "update repeatedly exceeded the 6h timeout",
     eq "keepmenu" "update repeatedly exceeded the 6h timeout",
     eq "klee" "update repeatedly exceeded the 6h timeout",
+    eq "vmagent" "updates via victoriametrics package",
     regex
       (string "python" *> few (psym isDigit) *> string "Packages.mmengine")
       "takes way too long to build",


### PR DESCRIPTION
vmagent is build out of the victoriametrics package since https://github.com/NixOS/nixpkgs/pull/308271 . 

I tried to add ` nixpkgs-update: no auto update`, which by itself does not result in being skipped. 
A short matrix chat revealed that one need to set `meta.position` so that nixpkhgs-update even considers the package.nix, tho that leads to more errors (complaining that source version is not defined in that file, so still skipping my skip).

Instead of raising more errors on running nixpkgs-update, adding vmagent to its skiplist is the only left idea in not receiving duplicate PRs.

If there is a better solution, please let me know.

On my opinion it would be best, to check skiplist before doing sanity checks in nixpkgs-update, but my haskell knowledge is basically non existing, so i can not suggest that with a PR.
