### PR TITLE
prMessage: recommend usage of nixpkgs-merge-bot

### DIFF
--- a/src/Update.hs
+++ b/src/Update.hs
@@ -607,6 +607,9 @@ prMessage updateEnv isBroken metaDescription metaHomepage metaChangelog rewriteM
 
        $maintainersCc
 
+       > [!TIP]
+       > As a maintainer, if your package is located under `pkgs/by-name/*`, you can comment **`@NixOS/nixpkgs-merge-bot merge`** to automatically merge this update using the [`nixpkgs-merge-bot`](https://github.com/NixOS/nixpkgs-merge-bot).
+
        ---
 
        Add a :+1: [reaction] to [pull requests you find important].

--- a/test_data/expected_pr_description_1.md
+++ b/test_data/expected_pr_description_1.md
@@ -86,6 +86,9 @@ nixpkgs-review comment body
 
 cc @maintainer1 for [testing](https://github.com/ryantm/nixpkgs-update/blob/main/doc/nixpkgs-maintainer-faq.md#r-ryantm-opened-a-pr-for-my-package-what-do-i-do).
 
+> [!TIP]
+> As a maintainer, if your package is located under `pkgs/by-name/*`, you can comment **`@NixOS/nixpkgs-merge-bot merge`** to automatically merge this update using the [`nixpkgs-merge-bot`](https://github.com/NixOS/nixpkgs-merge-bot).
+
 ---
 
 Add a :+1: [reaction] to [pull requests you find important].

--- a/test_data/expected_pr_description_2.md
+++ b/test_data/expected_pr_description_2.md
@@ -79,6 +79,9 @@ NixPkgs review skipped
 
 cc @maintainer1 for [testing](https://github.com/ryantm/nixpkgs-update/blob/main/doc/nixpkgs-maintainer-faq.md#r-ryantm-opened-a-pr-for-my-package-what-do-i-do).
 
+> [!TIP]
+> As a maintainer, if your package is located under `pkgs/by-name/*`, you can comment **`@NixOS/nixpkgs-merge-bot merge`** to automatically merge this update using the [`nixpkgs-merge-bot`](https://github.com/NixOS/nixpkgs-merge-bot).
+
 ---
 
 Add a :+1: [reaction] to [pull requests you find important].


### PR DESCRIPTION
Nixpkgs now uses the [`nixpkgs-merge-bot`](https://github.com/NixOS/nixpkgs-merge-bot) for maintainers who aren't committers, in order to combat Nixpkgs' "PR Crisis".

However, [some maintainers are unaware](https://github.com/NixOS/nixpkgs/pull/335431) that they can merge `nixpkgs-update` PRs using the bot, partly because the update message makes no mention of the bot.

This PR rectifies that by adding the following tip in the `maintainer pings` section:

> [!TIP]
> As a maintainer, if your package is located under `pkgs/by-name/*`, you can comment **`@NixOS/nixpkgs-merge-bot merge`** to automatically merge this update using the [`nixpkgs-merge-bot`](https://github.com/NixOS/nixpkgs-merge-bot).

---

I hereby license my contributions to this repository under:
Creative Commons Zero v1.0 Universal (SPDX Short Identifier: CC0-1.0)