### PR TITLE
Fix flake build failure

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,14 +5,14 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-for-manual": "nixpkgs-for-manual"
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1669050835,
-        "narHash": "sha256-4ppYRBBY6lIqwMNYp0XA2mku1lSPyX4JaoTf+gt5NDg=",
+        "lastModified": 1710694589,
+        "narHash": "sha256-5wa+Jzxr+LygoxSZuZg0YU81jgdnx2IY/CqDIJMOgec=",
         "owner": "ryantm",
         "repo": "mmdoc",
-        "rev": "cec02bafac9456bd1ed9b261b8d163a893885e5b",
+        "rev": "b6ddf748b1d1c01ca582bb1b3dafd6bc3a4c83a6",
         "type": "github"
       },
       "original": {
@@ -33,22 +33,6 @@
       "original": {
         "id": "nixpkgs",
         "type": "indirect"
-      }
-    },
-    "nixpkgs-for-manual": {
-      "locked": {
-        "lastModified": 1663819393,
-        "narHash": "sha256-SMWfyAOKRPBC95M8dhZJTlb0kHyilr2lKEAfQSHlM7I=",
-        "owner": "ryantm",
-        "repo": "nixpkgs",
-        "rev": "6a6caacfdd079a0fa249046514480a1c4597d861",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ryantm",
-        "ref": "minman",
-        "repo": "nixpkgs",
-        "type": "github"
       }
     },
     "root": {
@@ -72,6 +56,21 @@
         "owner": "NixOS",
         "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     },


### PR DESCRIPTION
Ran `nix flake lock --update-input mmdoc`, which fixes the following build failure:

```
error:
       … while fetching the input 'github:ryantm/nixpkgs/6a6caacfdd079a0fa249046514480a1c4597d861'

       error: unable to download 'https://github.com/ryantm/nixpkgs/archive/6a6caacfdd079a0fa249046514480a1c4597d861.tar.gz': HTTP error 404

       response body:

       404: Not Found
```