### PR TITLE
skiplist: add `ollama-rocm` and `ollama-cuda`

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -89,6 +89,8 @@ attrPathList =
     eq "keepmenu" "update repeatedly exceeded the 6h timeout",
     eq "klee" "update repeatedly exceeded the 6h timeout",
     eq "vmagent" "updates via victoriametrics package",
+    eq "ollama-rocm" "only `ollama` is explicitly updated (defined in the same file)",
+    eq "ollama-cuda" "only `ollama` is explicitly updated (defined in the same file)",
     regex
       (string "python" *> few (psym isDigit) *> string "Packages.mmengine")
       "takes way too long to build",


### PR DESCRIPTION
Only the `ollama` package is explicitly updated, since the gpu variants are defined in the same file and specialized with overrides.

It appears to me that `attrPathList` selects packages based on the name in the `nixpkgs` attrset, not by the package's `pname`. This is important for correctness, as the `pname` of `ollama-rocm` and `ollama-cuda` are both just `ollama`.