### PR TITLE
Make able to run on Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,6 @@
 
       treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs {
         projectRootFile = ".git/config";
-        programs.ormolu.enable = true;
       });
 
       buildAttrs = eachSystem (pkgs: {


### PR DESCRIPTION
As mentioned in #390 the flake produces error on Darwin systems, I fixed it using `eachSystem` to omit type in each supported system. In the end commented lines for `x86-64darwin` systems with comment about failing check on `x86-64linux` were deleted as now the check is running successfully (tested on NixOS 24.11).