### PR TITLE
bump timeouts

### DIFF
--- a/src/Check.hs
+++ b/src/Check.hs
@@ -62,7 +62,7 @@ hasVersion contents expectedVersion =
 
 checkTestsBuild :: Text -> IO Bool
 checkTestsBuild attrPath = do
-  let timeout = "10m"
+  let timeout = "30m"
   let args =
         [T.unpack timeout, "nix-build"]
           ++ nixBuildOptions

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -296,7 +296,7 @@ hasUpdateScript attrPath = do
 
 runUpdateScript :: MonadIO m => Text -> ExceptT Text m (ExitCode, Text)
 runUpdateScript attrPath = do
-  let timeout = "10m" :: Text
+  let timeout = "30m" :: Text
   (exitCode, output) <-
     ourReadProcessInterleaved $
       TP.setStdin (TP.byteStringInput "\n") $

--- a/src/NixpkgsReview.hs
+++ b/src/NixpkgsReview.hs
@@ -35,7 +35,7 @@ run ::
   Text ->
   Sem r Text
 run cache commit =
-  let timeout = "120m" :: Text
+  let timeout = "180m" :: Text
    in do
         -- TODO: probably just skip running nixpkgs-review if the directory
         -- already exists


### PR DESCRIPTION
These timeouts are only hit occasionally so they should be fine to bump without slowing down the overall rate of updates. 