### PR TITLE
skiplist: add `_7zz-rar`

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -148,7 +148,8 @@ nameList =
     eq "openbazaar" "multiple system hashes need to be updated at once",
     eq "eaglemode" "build hangs or takes way too long",
     eq "autoconf" "@prusnak asked to skip",
-    eq "abseil-cpp" "@andersk asked to skip"
+    eq "abseil-cpp" "@andersk asked to skip",
+    eq "_7zz-rar" "will be updated by _7zz proper"
   ]
 
 contentList :: Skiplist


### PR DESCRIPTION
`_7zz-rar` is `_7zz` with optional extras enabled

I'm not particularly familiar with haskel but that looks like this change should work

The intention is PRs will be made against `_7zz` instead of `_7zz-rar`

https://github.com/NixOS/nixpkgs/pull/360699