### PR TITLE
Gpg: init

### DIFF
--- a/nixpkgs-update.cabal
+++ b/nixpkgs-update.cabal
@@ -35,6 +35,7 @@ library
       File
       GH
       Git
+      Gpg
       Nix
       NixpkgsReview
       NVD

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17,6 +17,7 @@ let
     GIT = git;
     TREE = tree;
     GIST = gist;
+    GPG = gnupg;
     # TODO: are there more coreutils paths that need locking down?
     TIMEOUT = coreutils;
     NIXPKGSREVIEW = nixpkgs-review;

--- a/src/Gpg.hs
+++ b/src/Gpg.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Gpg
+  ( binPath,
+    recvKeys,
+    verify,
+  )
+where
+
+import Data.Maybe (fromJust)
+import qualified Data.Text as T
+import Language.Haskell.TH.Env (envQ)
+import OurPrelude
+
+binPath :: String
+binPath = fromJust ($$(envQ "GPG") :: Maybe String) <> "/bin"
+
+recvKeys ::
+  MonadIO m =>
+  Text ->
+  ExceptT Text m Text
+recvKeys releaseFingerprints =
+  ourReadProcess_
+    (proc (binPath <> "/gpg") (["--keyserver", "hkps://keyserver.ubuntu.com", "--recv-keys", T.unpack releaseFingerprints]))
+    & fmapRT (fst >>> T.strip)
+
+verify ::
+  MonadIO m =>
+  Text ->
+  Text ->
+  ExceptT Text m Text
+verify sigFilePath filePath =
+  ourReadProcess_
+    (proc (binPath <> "/gpg") (["--verify", T.unpack sigFilePath, T.unpack filePath]))
+    & fmapRT (fst >>> T.strip)
+
+

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -18,6 +18,8 @@ module Nix
     getIsBroken,
     getMaintainers,
     getPatches,
+    getReleaseFingerprints,
+    getReleaseSignature,
     getSrcUrl,
     hasPatchNamed,
     hasUpdateScript,
@@ -174,6 +176,13 @@ getDescription = nixEvalApplyRaw "p: p.meta.description or \"\""
 
 getHomepage :: MonadIO m => Text -> ExceptT Text m Text
 getHomepage = nixEvalApplyRaw "p: p.meta.homepage or \"\""
+
+getReleaseFingerprints :: MonadIO m => Text -> ExceptT Text m Text
+getReleaseFingerprints =
+  nixEvalApplyRaw "p: builtins.concatStringsSep \" \" (p.passthru.releaseFingerprints or [ ])"
+
+getReleaseSignature :: MonadIO m => Text -> ExceptT Text m Text
+getReleaseSignature = nixEvalApplyRaw "p: p.passthru.releaseSignaturePath or \"\""
 
 getSrcUrl :: MonadIO m => Text -> ExceptT Text m Text
 getSrcUrl =


### PR DESCRIPTION
THIS IS A PROOF OF CONCEPT AND PROBABLY NEEDS AN RFC AND COORDINATION WITH NIXPKGS

This is my WIP attempt to make `nixpkgs-update` verify that the new source is signed by upstream. It works by exposing a list of fingerprints of keys that are allowed to make new releases and a URL path to a detached signature file. This is implemented here first, because signed releases are most common in GitHub releases which is not supported by nix-update-script or any other update script in Nixpkgs.

One can imagine such a package:
```nix
stdenv.mkDerivation (finalAttrs: {
  pname = "limine";
  version = "9.2.1";

  src = fetchurl {
    url = "https://github.com/limine-bootloader/limine/releases/download/v${finalAttrs.version}/limine-${finalAttrs.version}.tar.gz";
    hash = "sha256-yHr8FMOKlWlSkkmkGADC6R4PHO7tHk38gwrJS/nPvvs=";
  };

  # ... snip ...

  passthru.releaseFingerprints = [ "05D29860D0A0668AAEFB9D691F3C021BECA23821" ];
  passthru.releaseSignature = "https://github.com/limine-bootloader/limine/releases/download/v${finalAttrs.version}/limine-${finalAttrs.version}.tar.gz.sig";
})
```

## ~~Bikeshedding~~ Open Questions

- [ ] How should releaser fingerprints be declared in the package? This patch currently refers to `passthru.releaseFingerprints` but it's naming can be bikeshedded (and it can possibly be moved under meta?)
- [ ] How should the release signature path be declared in the package? This patch currently refers to `passthru.releaseSignature` but it's naming can be bikeshedded (and it can possibly be moved under meta?)
- [ ] How safe is it to rely on Ubuntu's keyservers? Please note that in my experience they are the fastest keyserver. An alternative would be to distribute public keys thru a "nixpkgs-keyring" like Arch Linux does for its package maintainers (not sure how good of an idea it is to maintain a repository of upstream developers tho). A Nix keyserver is out of scope.

## Todo

- [ ] - GPG does not easily allow temporarily adding a key, attempting to do that involves creating a new keyring in a temporary directory. But this is necessary to make sure *only* the keys declared in the package are allowed to make releases (otherwise, any key that makes it into the user's keyring, whether added manually or when updating a different package, will be seen as trusted which we don't want for obvious reasons)
- [ ] Lots of other stuff