### PR TITLE
Skiplist: Fix GNOME exclusion

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -165,7 +165,7 @@ contentList =
     infixOf "bundlerEnv" "Derivation contains bundlerEnv",
     infixOf "buildPerlPackage" "Derivation contains buildPerlPackage",
     -- Specific skips for classes of packages
-    infixOf "teams.gnome.members" "Do not update GNOME during a release cycle",
+    infixOf "teams.gnome" "Do not update GNOME during a release cycle",
     infixOf "https://downloads.haskell.org/ghc/" "GHC packages are versioned per file"
   ]
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/400458 broke this by replacing `meta.maintainers = [ teams.gnome.members ]` with `meta.teams = [ teams.gnome ]`