### PR TITLE
skiplist: add floorp

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -156,7 +156,8 @@ nameList =
     eq "_7zz-rar" "will be updated by _7zz proper",
     eq "ncbi-vdb" "updating this alone breaks sratoolkit",
     eq "sratoolkit" "tied to version of ncbi-vdb",
-    eq "libsignal-ffi" "must match the version required by mautrix-signal"
+    eq "libsignal-ffi" "must match the version required by mautrix-signal",
+    eq "floorp" "big package, does not update hashes correctly (https://github.com/NixOS/nixpkgs/pull/424715#issuecomment-3163626684)"
   ]
 
 contentList :: Skiplist


### PR DESCRIPTION
Hopefully this addition is correct. 

It's a big package (Firefox fork), thus
a) expensive to build
b) due to a) often way to slow for browser updates, which must be done
   in a timely manner
c) seems to sometimes not update hashes correctly, most recently in https://github.com/NixOS/nixpkgs/pull/424715#issuecomment-3163626684

So just skip it and save quite a bit of resources.