### PR TITLE
Skiplist: add vlagent package

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -91,6 +91,7 @@ attrPathList =
     eq "flint" "update repeatedly exceeded the 6h timeout",
     eq "keepmenu" "update repeatedly exceeded the 6h timeout",
     eq "klee" "update repeatedly exceeded the 6h timeout",
+    eq "vlagent" "updates via victorialogs package",
     eq "vmagent" "updates via victoriametrics package",
     eq "ollama-rocm" "only `ollama` is explicitly updated (defined in the same file)",
     eq "ollama-cuda" "only `ollama` is explicitly updated (defined in the same file)",


### PR DESCRIPTION
Similar action than for https://github.com/nix-community/nixpkgs-update/pull/439/ but for the VictoriaLogs agent.

Agent is build from the VictoriaLogs package in nixpkgs but with different arguments to exclude the server components.

Updates should go via the full package definition.

Example PR for of-borg updating the agent  https://github.com/NixOS/nixpkgs/pull/437621#event-19403049229

 