### PR TITLE
skiplist: add netbird child packages

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -186,7 +186,12 @@ nameList =
       "updates through discord only https://github.com/NixOS/nixpkgs/issues/468956",
     eq
       "discord-development"
-      "updates through discord only https://github.com/NixOS/nixpkgs/issues/468956"
+      "updates through discord only https://github.com/NixOS/nixpkgs/issues/468956",
+    eq "netbird-management" "it's an override of netbird",
+    eq "netbird-relay" "it's an override of netbird",
+    eq "netbird-signal" "it's an override of netbird",
+    eq "netbird-ui" "it's an override of netbird",
+    eq "netbird-upload" "it's an override of netbird"
   ]
 
 contentList :: Skiplist


### PR DESCRIPTION
Tried solving this with the "no auto update" comment, but it didn't work - https://github.com/NixOS/nixpkgs/pull/495822, so adding to the skiplist instead.

Not using `prefix "netbird-"` intentionally, because `netbird-dashboard` is a separate package and not an override of the `netbird` derivation like others.